### PR TITLE
Kyle's proposed code changes to accommodate BIDS formatted datasets

### DIFF
--- a/functions/batch_spm_realign.m
+++ b/functions/batch_spm_realign.m
@@ -47,7 +47,7 @@ function [b] = batch_spm_realign(b)
 % Check if realignment was already run and if so, whether it should be run
 % again
 runflag = 1;
-if size(spm_select('FPList', fullfile(b.dataDir, b.runs{1}), '^rp'), 1) > 0 % check only for first run
+if size(spm_select('FPListRec', b.dataDir, ['^rp.*' b.runs{1} '.*\.txt']), 1) > 0 % check only for first run
     if b.auto_accept
         response = 'n';
     else
@@ -78,11 +78,10 @@ if runflag
 end
 
 % Get file information for each run & store for future use
-b.meanfunc = spm_select('FPList', fullfile(b.dataDir, b.runs{1}), '^mean.*\.nii'); % mean func is written only for first run
+b.meanfunc = spm_select('FPListRec', b.dataDir, ['^mean.*' b.runs{1} '.*\.nii']); % mean func is written only for first run
 for i = 1:length(b.runs)
-    tmp = spm_select('FPList', fullfile(b.dataDir, b.runs{i}), '^rp');
-    b.rundir(i).rp = tmp(1,:);
-    b.rundir(i).rfiles = spm_select('ExtFPList', fullfile(b.dataDir, b.runs{i}), '^r.*\.nii');
+    b.rundir(i).rp     = spm_select('FPListRec', b.dataDir, ['^rp.*' b.runs{i} '.*\.txt']);
+    b.rundir(i).rfiles = spm_select('ExtFPListRec', b.dataDir, ['^r.*'  b.runs{i} '.*\.nii']);
     fprintf('%0.0f: Realignment parameters file: %s\n', i, b.rundir(i).rp);
 end
 

--- a/functions/create_spike_regs.m
+++ b/functions/create_spike_regs.m
@@ -52,7 +52,8 @@ for j = 1:length(b.runs)
     numBad(j) = (100*length(bad_timepoints)/size(motion,1));
     
     % write out list of bad timepoints
-    filename = fullfile(b.dataDir, b.runs{j}, [spikePrefix 'bad_timepoints.txt']);
+    filedir  = fullfile(b.dataDir, 'func');
+    filename = fullfile(filedir, [spikePrefix 'bad_timepoints' b.runs{j} '.txt']);
     fprintf('-- Writing out %s\n', filename);
     dlmwrite(filename, bad_timepoints, 'delimiter', '\t');
    
@@ -70,7 +71,7 @@ for j = 1:length(b.runs)
     allreg = [motion spikereg];
     
     % write out new rp regressors including spike regs
-    filename = fullfile(b.dataDir, b.runs{j}, [spikePrefix 'spike_regs_rp.txt']);
+    filename = fullfile(filedir, [spikePrefix 'spike_regs_rp' b.runs{j} '.txt']);
     fprintf('-- Writing out %s\n\n', filename);
     dlmwrite(filename, allreg, 'delimiter', '\t');
     

--- a/functions/find_nii.m
+++ b/functions/find_nii.m
@@ -36,12 +36,12 @@ for irun = 1:length(b.runs)
     
     % Select this run's full nii timeseries
     rundir   = fullfile(b.dataDir, b.runs{irun});
-    wildcard = [ '^' b.rawdataFP '.*\.nii'];
-    b.rundir(irun).files = spm_select('ExtFPList', rundir, wildcard, Inf);
+    wildcard = [ '^' b.curSubj '.*' b.runs{irun} '.*\.nii'];
+    b.rundir(irun).files = spm_select('ExtFPListRec', b.dataDir, wildcard, Inf);
     
     % Check if files are found
     if size(b.rundir(irun).files, 1) > 0
-        fprintf('In directory %s:\n%0.0f nii files found.\n', rundir, size(b.rundir(irun).files, 1));
+        fprintf('%0.0f nii files found.\n', size(b.rundir(irun).files, 1));
     else
         % Check for gz file that matches prefix
         gzfiletest = dir([rundir filesep b.rawdataFP '*nii.gz']);

--- a/functions/run_art_global.m
+++ b/functions/run_art_global.m
@@ -65,7 +65,7 @@ FD_run       = cell(1,length(b.rundir));
 % Check if ArtRepair was already run and if so, whether it should be run
 % again
 runflag = 1;
-if size(spm_select('fplist',fullfile(b.dataDir, b.runs{1}), '^art'), 1) > 0 % check only for first run
+if size(spm_select('FPlistRec', b.dataDir, '^art'), 1) > 0
     if b.auto_accept
         response = 'n';
     else

--- a/memolab_batch_qa.m
+++ b/memolab_batch_qa.m
@@ -33,7 +33,7 @@ voxsize     = 3.0;
 % QAdir     = Name of output QA directory
 
 dataDir     = '/path/to/data';
-scriptdir   = '/path/to/memolab_MRI_qa';
+scriptdir   = fileparts(mfilename('fullpath'));
 QAdir       = 'Name_of_QA_Directory';
 
 %-- Info for Subjects
@@ -235,7 +235,7 @@ for i = 1:length(subjects)
     % Run art_global
     fprintf('--Running Art Global--\n')
     [all_suspects, FD_mean_run, FD_run] = run_art_global(b);
-    b.mask = fullfile(b.dataDir, b.runs{1}, 'ArtifactMask.nii');
+    b.mask = spm_select('ExtFPListRec', b.dataDir, 'ArtifactMask.nii', 1);
     fprintf('------------------------------------------------------------\n')
     fprintf('\n')
    


### PR DESCRIPTION
Hey @ritcheym ,

I just ran the memolab-fmri-qa pipeline on the Haxby dataset (per your suggestion) and I remembered something. One of the reasons why I did NOT run the memolab-fmri-qa pipeline was that this pipeline **does** **not** **accommodate** **BIDS** **formatted** **datasets**.

I was forced to make the changes below to the code, which I am suggesting here be permeant changes to the `memolab-fmri-qa` pipeline. I figured that all fMRI datasets we encounter as a lab from here on out should be BIDS formatted. I also wanted to try doing a pull request :).

A summary of the changes:

1.) I utilized the recursive functionality of the spm_select function to grab files where appropriate. I made corresponding changes to the regular expressions. What is nice about the BIDS format is that all files have **unique**, **informative** **filenames**, making recursive selection of them do-able.

2.) I was forced to give the output files of the `create_spike_regs` function unique filenames. This is because there are no run specific folders in BIDS format, so we need to be able to differentiate successive runs from one another.

3.) In the base `memolab_batch_qa` script, I made a suggested change to the defaults. The combinations of the functions `fileparts(mfilename('fullpath'))` should automatically return the path of the `memolab_batch_qa.m` file, which should be the scripts directory. This makes sense as a default in the pipeline.