### PR TITLE
Final Debugs for the BIDS Format Conversion

### DIFF
--- a/functions/batch_spm_realign.m
+++ b/functions/batch_spm_realign.m
@@ -15,8 +15,7 @@ function [b] = batch_spm_realign(b)
 %       b.dataDir     = fullpath string to the directory where the functional MRI data
 %                       is being stored
 %
-%       b.runs        = cellstring with the name of the directories containing
-%                       each functional run
+%       b.runs        = cellstring with IDs for each functional time series
 %
 %       b.auto_accept = a true/false variable denoting whether or not the 
 %                       user wants to be prompted
@@ -47,7 +46,7 @@ function [b] = batch_spm_realign(b)
 % Check if realignment was already run and if so, whether it should be run
 % again
 runflag = 1;
-if size(spm_select('FPListRec', b.dataDir, ['^rp.*' b.runs{1} '.*\.txt']), 1) > 0 % check only for first run
+if size(spm_select('FPListRec', b.dataDir, ['^rp.*' b.runs{1} '.*bold\.txt']), 1) > 0 % check only for first run
     if b.auto_accept
         response = 'n';
     else
@@ -77,12 +76,15 @@ if runflag
     spm_reslice(b.allfiles);
 end
 
+fprintf('\n--Finding realignmnet files--\n')
 % Get file information for each run & store for future use
-b.meanfunc = spm_select('FPListRec', b.dataDir, ['^mean.*' b.runs{1} '.*\.nii']); % mean func is written only for first run
+b.meanfunc = spm_select('FPListRec', b.dataDir, ['^mean.*' b.runs{1} '.*bold\.nii']); % mean func is written only for first run
+fprintf('\nMean: %s\n', b.meanfunc)
 for i = 1:length(b.runs)
-    b.rundir(i).rp     = spm_select('FPListRec', b.dataDir, ['^rp.*' b.runs{i} '.*\.txt']);
-    b.rundir(i).rfiles = spm_select('ExtFPListRec', b.dataDir, ['^r.*'  b.runs{i} '.*\.nii']);
-    fprintf('%0.0f: Realignment parameters file: %s\n', i, b.rundir(i).rp);
+    b.rundir(i).rp     = spm_select('FPListRec', b.dataDir, ['^rp.*' b.runs{i} '.*bold\.txt']);
+    b.rundir(i).rfiles = spm_select('ExtFPListRec', b.dataDir, ['^r.*'  b.runs{i} '.*bold\.nii']);
+    fprintf('%02d:   %s\n', i, b.rundir(i).rp)
+    fprintf('%02d:   %0.0f rfiles found.\n', i, length(b.rundir(i).rfiles))
 end
 
 end % realign function

--- a/functions/compute_snr.m
+++ b/functions/compute_snr.m
@@ -98,7 +98,7 @@ for j = 1:length(b.runs)
     snr(snr>2000)   = NaN; % mask out abnormal values
     snr(snr==0)     = NaN;
     snrmean         = [snrmean nanmean(nanmean(nanmean(snr(:,:,:))))];
-    snrmean_mid     = [snrmean_mid nanmean(nanmean(snr(:,:,(size(data,3)/2))))];
+    snrmean_mid     = [snrmean_mid nanmean(nanmean(snr(:,:,(ceil(size(data,3)/2)))))];
     snr(isnan(snr)) = 0;
     
     %output files to the QA dir
@@ -190,12 +190,13 @@ save_figs(s, 'tsnr_plot', b, figFormat, pdfReport, 6, 6); % square plot
 % % Plot spatial SNR
 figure(sp)
 maxrunlen = size(spatial_SNR, 2);
-colors = {'r','g','b','k','y','m','c'};
+%colors = {'r','g','b','k','y','m','c'};
+colors = num2cell(hsv(size(spatial_SNR_runs,2)), 2);
 for j = 1:size(spatial_SNR_runs,2) % coded this way in case runs have different lengths
     if size(spatial_SNR_runs{j}, 2) > maxrunlen
         maxrunlen = size(spatial_SNR_runs{j}, 2);
     end
-    plot(spatial_SNR_runs{j}, colors{(mod(j-1,length(colors))+1)}); % cycle through colors
+    plot(spatial_SNR_runs{j}, 'Color', colors{(mod(j-1,length(colors))+1)}); % cycle through colors
     hold on
 end
 hold off

--- a/functions/create_spike_regs.m
+++ b/functions/create_spike_regs.m
@@ -23,8 +23,8 @@ function [b, numBad]= create_spike_regs(b, all_suspects, spikePrefix)
 %
 %       b       = memolab_MRI_batch structure
 %
-%       numBad = a double vector which contains the number of bad
-%                timepoints flagged for each run
+%       numBad = a vector which contains the number of bad timepoints 
+%                flagged for each run
 %
 % See also: art_global_qa, memolab_batch_qa
 
@@ -53,7 +53,7 @@ for j = 1:length(b.runs)
     
     % write out list of bad timepoints
     filedir  = fullfile(b.dataDir, 'func');
-    filename = fullfile(filedir, [spikePrefix 'bad_timepoints' b.runs{j} '.txt']);
+    filename = fullfile(filedir, [spikePrefix 'bad_timepoints_' b.runs{j} '.txt']);
     fprintf('-- Writing out %s\n', filename);
     dlmwrite(filename, bad_timepoints, 'delimiter', '\t');
    
@@ -71,7 +71,7 @@ for j = 1:length(b.runs)
     allreg = [motion spikereg];
     
     % write out new rp regressors including spike regs
-    filename = fullfile(filedir, [spikePrefix 'spike_regs_rp' b.runs{j} '.txt']);
+    filename = fullfile(filedir, [spikePrefix 'spike_regs_rp_' b.runs{j} '.txt']);
     fprintf('-- Writing out %s\n\n', filename);
     dlmwrite(filename, allreg, 'delimiter', '\t');
     

--- a/functions/run_theplot.m
+++ b/functions/run_theplot.m
@@ -17,7 +17,7 @@ function run_theplot(b, FD_run)
 %                    SPM's realignment procedure
 %
 %       b.dataDir  = fullpath string to the directory where the functional MRI data
-%                   is being stored
+%                    is being stored
 %
 %       b.QAdir    = string, name of the directory where QA output is stored
 %
@@ -25,10 +25,9 @@ function run_theplot(b, FD_run)
 %                    runs, with the fields:
 %
 %           b.rundir(n).rfiles = full path to run n's realigned 
-%                                and resliced bold_nii time series
+%                                and resliced bold nii time series
 %
-%       b.runs    = cellstring with the name of the directories containing
-%                   each functional run.
+%       b.runs    = cellstring with IDs for each functional time series
 %
 %   FD_run = a cell array containing vectors of the framewise displacement
 %            values for each timepoint in all functional runs, where 
@@ -47,7 +46,7 @@ function run_theplot(b, FD_run)
        isempty(spm_select('FPList', segDir, '^c2')) || ...
        isempty(spm_select('FPList', segDir, '^c3'))
         
-        fprintf('--Segmentation has not yet been run. Running segmentation...--\n')
+        fprintf('--Segmentation of the mean func has not yet been run. Running segmentation...--\n')
         newsegment(b.meanfunc);
         fprintf('------------------------------------------------------------\n')
         fprintf('\n')
@@ -62,7 +61,7 @@ function run_theplot(b, FD_run)
     
     % For each run...
     for r = 1:length(b.rundir)
-        fprintf('%s (%d / %d runs)\n', b.runs{r}, r, length(b.rundir))
+        fprintf('\n%s (%d / %d runs)\n', b.runs{r}, r, length(b.rundir))
         theplot(b.meanfunc, b.rundir(r).rfiles, full_path_to_QAdir, FD_run{r}, b.runs{r})
         fprintf('------------------------------------------------------------\n')
         fprintf('\n')

--- a/functions/save_sum_info.m
+++ b/functions/save_sum_info.m
@@ -9,8 +9,8 @@ function [] = save_sum_info(b, FD_mean_run, FD_run, snrmean, snrmean_mid, spatia
 %
 %       b = memolab qa batch structure containing the fields:
 %
-%           b.runs      = cellstring with the name of the directories containing
-%                         each functional run
+%           b.runs      = cellstring with IDs for each functional time
+%                         series
 %
 %           b.curSubj   = string, the ID for the current subject
 %

--- a/functions/theplot.m
+++ b/functions/theplot.m
@@ -70,6 +70,14 @@ if ~exist(outdir, 'dir')
     mkdir(outdir)
 end
 
+% Does the fd vector match the length of the bold time series?
+if size(bold_image,1) ~= length(fd)
+    fprintf('\nImage Frames:\n\n')
+    disp(bold_image)
+    fprintf('\nLength of the FD vector: %0.0f\n\n', length(fd))
+    assert(size(bold_image,1) == length(fd), 'The number of bold image frames does NOT match the number of framewise displacement values. See above.')
+end
+
 %====================================================================================
 %			Step 2: Load, mask, and manipluate various images
 %====================================================================================


### PR DESCRIPTION
@ritcheym,

This pull request finishes what was started in the previous pull request. The pipeline should be completely converted to work with BIDS formatted datasets following this pull request.

Major changes in this pull request:

1. Added 'bold' to the various `spm_select.m` regular expressions. When testing the pipeline on @rsamide 's data, the pipeline was inadvertently grabbing the `*sbref.nii` images she had in her dataset. The script(s) are now designed to **ONLY** select `*bold.nii` images.  
2. Resolved a bug in `compute_snr` where the middle slice was NOT being selected properly when the data had an odd number of slices [ @rsamide 's data had 69 slices in it ]. See `update to computer_snr` commit.  
3. Added a new feature to `compute_snr.m`: `compute_snr.m` now uses a larger color palette when plotting the spatial snr parameters. @rsamide mentioned that she couldn't tell the runs apart with the color scheme used previously.
4. Forced the `art_global` module to give the output files `ArtifactMask.nii` and `art_suspects.txt` *unique filenames*. The pipeline was overwriting these files for each run when the data were in BIDS format (because there are NOT separate subdirectories for each functional run). Unique filenames resolves this issue.    
5. Removed the `voxsize` and `rawDataFilePrefix` parameters, as these are no longer used by the pipeline.  
6. Because of the problem in number 4 above, I decided to *change the whole brain mask used in* compute_snr.m. The script now takes the mean functional image, runs `art_automask.m` on it, and then uses that as the whole brain mask for `compute_snr.m`.